### PR TITLE
(issue-1) Fix broken references.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,6 @@
 source 'https://rubygems.org/'
 
-gem 'hiera-eyaml', ">=1.3.8"
+gem 'hiera-eyaml', ">=2.1.0"
 gem 'rbnacl'
 
 group :development do

--- a/hiera-eyaml-secretbox.gemspec
+++ b/hiera-eyaml-secretbox.gemspec
@@ -19,5 +19,5 @@ Gem::Specification.new do |gem|
   gem.require_paths = ["lib"]
 
   gem.add_runtime_dependency 'rbnacl', '~> 3.0'
-  gem.add_runtime_dependency 'hiera-eyaml', '~> 2.0'
+  gem.add_runtime_dependency 'hiera-eyaml', '~> 2.1'
 end

--- a/lib/hiera/backend/eyaml/encryptors/secretbox.rb
+++ b/lib/hiera/backend/eyaml/encryptors/secretbox.rb
@@ -1,7 +1,8 @@
 require 'base64'
 require 'rbnacl'
 require 'hiera/backend/eyaml/encryptor'
-require 'hiera/backend/eyaml/utils'
+require 'hiera/backend/eyaml/encrypthelper'
+require 'hiera/backend/eyaml/logginghelper'
 require 'hiera/backend/eyaml/options'
 
 class Hiera
@@ -71,11 +72,11 @@ class Hiera
             pub = key.public_key
             pub_b64 = Base64.encode64 pub.to_bytes
 
-            Utils.ensure_key_dir_exists private_key
-            Utils.write_important_file :filename => private_key, :content => key_b64, :mode => 0600
-            Utils.ensure_key_dir_exists public_key
-            Utils.write_important_file :filename => public_key, :content => pub_b64, :mode => 0644
-            Utils.info 'Keys created OK'
+            EncryptHelper.ensure_key_dir_exists private_key
+            EncryptHelper.write_important_file :filename => private_key, :content => key_b64, :mode => 0600
+            EncryptHelper.ensure_key_dir_exists public_key
+            EncryptHelper.write_important_file :filename => public_key, :content => pub_b64, :mode => 0644
+            LoggingHelper.info 'Keys created OK'
 
           end
 


### PR DESCRIPTION
Required the libraries that currently hold the methods used in this
module. Removed requiring the Utils class since none of its methods
are used anymore.

This commit also bumps the dependency on hiera-eyaml to 2.1.0
since these changes break compatibility with older versions.